### PR TITLE
update dockerfile to remove deprecated MAINTAINER tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node
 
-MAINTAINER Jayaram Kancherla <jayaram.kancherla@gmail.com>
+LABEL maintainer="Jayaram Kancherla <jayaram.kancherla@gmail.com>"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends vim nginx git default-jre && \


### PR DESCRIPTION
Just noticed a warning about it when I was trying to run the docker image